### PR TITLE
Send timestamp as ms instead of iso string

### DIFF
--- a/packages/greenbox-data/lib/index.ts
+++ b/packages/greenbox-data/lib/index.ts
@@ -17,7 +17,7 @@ export * from "./tattoos";
 export * from "./trophies";
 export * from "./iotms";
 
-export type Meta = { name: string; id: string; revision: number; timestamp: string };
+export type Meta = { name: string; id: string; revision: number; timestamp: number };
 
 export interface RawSnapshotData {
   meta: Meta;

--- a/packages/greenbox-script/src/greenbox.ts
+++ b/packages/greenbox-script/src/greenbox.ts
@@ -194,7 +194,7 @@ function checkMeta() {
   return {
     name: myName(),
     id: myId(),
-    timestamp: new Date().toISOString(),
+    timestamp: new Date().getTime(),
     revision: getRevision(),
   };
 }

--- a/packages/greenbox-web/src/components/MetaInfo.tsx
+++ b/packages/greenbox-web/src/components/MetaInfo.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@chakra-ui/react";
-import { format, formatDistance, intlFormat, parseISO } from "date-fns";
+import { format, formatDistance, intlFormat } from "date-fns";
 import { Meta } from "greenbox-data";
 import { useEffect, useMemo, useState } from "react";
 
@@ -9,7 +9,7 @@ type Props = {
 
 export default function MetaInfo({ meta }: Props) {
   const [now, setNow] = useState(new Date());
-  const date = useMemo(() => parseISO(meta.timestamp), [meta.timestamp]);
+  const date = useMemo(() => new Date(meta.timestamp));
   const humanDate = useMemo(
     () =>
       intlFormat(date, {


### PR DESCRIPTION
This should fix the time since value being wrong, but old links will probably stop working because the type changed.