### PR TITLE
Handle mutex skill groups a little better

### DIFF
--- a/packages/greenbox-data/lib/skills.ts
+++ b/packages/greenbox-data/lib/skills.ts
@@ -6,6 +6,13 @@ export const enum SkillStatus {
   HARDCORE = 2,
 }
 
+export const mutexSkillGroups = [
+  {
+    skillIds: [191, 192, 193],
+    groupName: "Drippy Skill",
+  },
+];
+
 export type RawSkill = [id: number, status: SkillStatus, level: number];
 
 export const compressSkills = (skills: RawSkill[]) =>

--- a/packages/greenbox-web/src/components/Skills.tsx
+++ b/packages/greenbox-web/src/components/Skills.tsx
@@ -68,6 +68,20 @@ export default function Skills() {
     [groupedSkills],
   );
 
+  const mutexSkillGroups = [
+    {
+      skillIds: [191, 192, 193],
+      groupName: "Drippy Skill",
+    },
+  ];
+
+  const impossibleSkillCount = mutexSkillGroups.reduce(
+    (accumulator, mutexSkillGroup) =>
+      accumulator + mutexSkillGroup.skillIds.length - 1,
+    0,
+  );
+  const skillsPermable = skills.length - impossibleSkillCount;
+
   // Not ideal but we accumulate mutually exclusive groups of skills in this array as we traverse the skills array (if necessary).
   const skillGroup = [] as SkillType[];
 
@@ -80,15 +94,15 @@ export default function Skills() {
         {
           color: "partial",
           value: totalSoftcorePermed,
-          name: `${totalSoftcorePermed} / ${skills.length} softcore permed`,
+          name: `${totalSoftcorePermed} / ${skillsPermable} softcore permed`,
         },
         {
           color: "complete",
           value: totalHardcorePermed,
-          name: `${totalHardcorePermed} / ${skills.length} hardcore permed`,
+          name: `${totalHardcorePermed} / ${skillsPermable} hardcore permed`,
         },
       ]}
-      max={skills.length}
+      max={skillsPermable}
     >
       {bucketedSkills.map(([bucket, contents]) => {
         const allHardcorePermed = contents.every(
@@ -104,28 +118,32 @@ export default function Skills() {
           >
             <SimpleGrid columns={6} spacing={1}>
               {contents.map((s) => {
-                switch (s.id) {
-                  case 191:
-                  case 192:
-                  case 193:
-                    skillGroup.push(s);
-                    if (s.id !== 193) return null;
-
-                    const group = [...skillGroup];
-                    skillGroup.length = 0;
-                    return (
-                      <MutexSkills
-                        key={s.id}
-                        groupName="Drippy Skill"
-                        skills={group}
-                        statuses={group.map(
-                          (s) => idToSkill[s.id]?.[1] ?? SkillStatus.NONE,
-                        )}
-                      />
-                    );
-                  default:
-                    return <Skill key={s.id} id={s.id} />;
+                const matchingMutexSkillGroup = mutexSkillGroups.find(
+                  (mutexSkillGroup) => mutexSkillGroup.skillIds.includes(s.id),
+                );
+                if (matchingMutexSkillGroup) {
+                  skillGroup.push(s);
+                  if (
+                    matchingMutexSkillGroup.skillIds[
+                      matchingMutexSkillGroup.skillIds.length - 1
+                    ] !== s.id
+                  ) {
+                    return null;
+                  }
+                  const group = [...skillGroup];
+                  skillGroup.length = 0;
+                  return (
+                    <MutexSkills
+                      key={s.id}
+                      groupName={matchingMutexSkillGroup.groupName}
+                      skills={group}
+                      statuses={group.map(
+                        (s) => idToSkill[s.id]?.[1] ?? SkillStatus.NONE,
+                      )}
+                    />
+                  );
                 }
+                return <Skill key={s.id} id={s.id} />;
               })}
             </SimpleGrid>
           </SkillBucket>


### PR DESCRIPTION
This will make it easier to add any future mutually exclusive skill groups that are added in the future (if that ever happens again), but more importantly it prevents them from being counted against the total number of permable skills in a way that isn't just hardcoding skills.length - 2, making the bar for skills possible to fill completely instead of always having at least a little sliver of grey.

Tested locally with [this URL](http://localhost:5173/?d=(%27meta!%27name%3Asoolar%20the%20second%2Cid%3A2463557%2Ctimestamp%3A17B766276246%2Crevision%3A27695%2Cversion%3A2zskillQNXyM.BXyGJ2%7DJYJ4%7D.G2NBD0Gg0G-y-20J1%7DJYDJ7%7DBx%7B2%7D-J6%7DG%7B5%7DG2M2XD2xXJ4%7DgMJ1YDBG20GD2.BMJO%7D2LXDx0G-DLMy0R-L0G0G-xL0RDX2LX20RDL-20R-D%2CEEEEEEEBJYKKKKKENBSzfamiliarQVVV-gMV-NB-.B2xB2xB-B-gBG-y0RDB-NBDVDBD2SXBSXX2XgM*Vx*VDVg*VVVg*G2EN0GD*G-VDyD*2ztrophieQW1BOB1IB1B1I1B1.OBAIIIBON_1.1I10PAOBOWBAWBOIWN.1.1IIW.1BO.OI1._B1zmiscTattooQO092I10POBOB_OI1II1IB_IzoutfitTattooQ-xSSM.SB2MBDSN2MWND.2NSNBS1SOSW1BSByg12P2.DW1_O_1I_W1B_B1zpathQ0PPPP1_O_0PN.PcU0PPPPPPPPINPcKFB%2CWWFUFiAF.F2A%2CFBF.F4HUHZkA%2C0H0HjPHcH61H.%2CnHIH0HaAFnAUHdHbA0F0H2Hb1H0HbOZBZBZNFb1ziotmQN.SMSxB0RRRRRRRRRRD2zitemQ3139C140q46q47q51q53q54q55q56q61q62w12w28w80w85w90w93w95w96w97C405C407C408C410C4O%27)-g2.BBAO1B00C%2C3D22ENNNN.F%2CB%2CG--H1U01J2%7BK%2C%2CL%2CyGM0DN..O11PAAQs!%27RGGS02U%2CIV2*WBIX0-Y3%7DZ0%2C_0AgDDqC2wC3xMDy2Bz%27~%01zyxwqg_ZYXWVUSRQPONMLKJIHGFEDCBA.-_), the skills bar appears completely full. Compare to live with [this URL](http://greenbox.loathers.net/?d=(%27meta!%27name%3Asoolar%20the%20second%2Cid%3A2463557%2Ctimestamp%3A17B766276246%2Crevision%3A27695%2Cversion%3A2zskillQNXyM.BXyGJ2%7DJYJ4%7D.G2NBD0Gg0G-y-20J1%7DJYDJ7%7DBx%7B2%7D-J6%7DG%7B5%7DG2M2XD2xXJ4%7DgMJ1YDBG20GD2.BMJO%7D2LXDx0G-DLMy0R-L0G0G-xL0RDX2LX20RDL-20R-D%2CEEEEEEEBJYKKKKKENBSzfamiliarQVVV-gMV-NB-.B2xB2xB-B-gBG-y0RDB-NBDVDBD2SXBSXX2XgM*Vx*VDVg*VVVg*G2EN0GD*G-VDyD*2ztrophieQW1BOB1IB1B1I1B1.OBAIIIBON_1.1I10PAOBOWBAWBOIWN.1.1IIW.1BO.OI1._B1zmiscTattooQO092I10POBOB_OI1II1IB_IzoutfitTattooQ-xSSM.SB2MBDSN2MWND.2NSNBS1SOSW1BSByg12P2.DW1_O_1I_W1B_B1zpathQ0PPPP1_O_0PN.PcU0PPPPPPPPINPcKFB%2CWWFUFiAF.F2A%2CFBF.F4HUHZkA%2C0H0HjPHcH61H.%2CnHIH0HaAFnAUHdHbA0F0H2Hb1H0HbOZBZBZNFb1ziotmQN.SMSxB0RRRRRRRRRRD2zitemQ3139C140q46q47q51q53q54q55q56q61q62w12w28w80w85w90w93w95w96w97C405C407C408C410C4O%27)-g2.BBAO1B00C%2C3D22ENNNN.F%2CB%2CG--H1U01J2%7BK%2C%2CL%2CyGM0DN..O11PAAQs!%27RGGS02U%2CIV2*WBIX0-Y3%7DZ0%2C_0AgDDqC2wC3xMDy2Bz%27~%01zyxwqg_ZYXWVUSRQPONMLKJIHGFEDCBA.-_) which has a little grey sliver at the end.