### PR TITLE
Additional reward item tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   },
   "scripts": {
     "build": "yarn workspace greenbox-script run build && yarn workspace greenbox-web run build",
-    "format": "yarn workspaces foreach --all run format"
+    "format": "yarn workspaces foreach --all run format",
+    "preview": "yarn workspace greenbox-web run preview",
+    "watch": "yarn workspace greenbox-web run watch"
   },
   "packageManager": "yarn@4.2.1"
 }

--- a/packages/greenbox-data/data/items.ts
+++ b/packages/greenbox-data/data/items.ts
@@ -1,4 +1,97 @@
 export const specialItems = [
+  //// Quest Rewards
+  // Marty's Quest
+  2719, // hand-carved bokken
+  2720, // hand-carved bow
+  2721, // hand-carved staff
+
+  // secret from the future
+  4108, // monstrous monocle
+  4109, // musty moccasins
+  4110, // molten medallion
+  4111, // brazen bracelet
+  4112, // bitter bowtie
+  4113, // bewitching boots
+
+  // Reflection of a Map
+  4510, // walrus ice cream
+  4511, // beautiful soup
+  4512, // eggman noodles
+  4513, // Vial of jus de larmes
+  4515, // Lobster qua Grill
+  4516, // missing wine
+  4519, // ittah bittah hookah
+
+  // psychoanalytic jar
+  6057, // Meatcleaver
+  6067, // Truthsayer
+  6108, // Ginsu™
+  6133, // White Dragon Fang
+  6146, // Sword of Procedural Generation
+  6157, // Byte
+  6168, // Bloodbath
+
+  // We All Wear Masks
+  7131, // silver cow creamer
+  7134, // wolf whistle
+  7137, // witch's bra
+  7140, // spinning wheel
+  7143, // hare pin
+
+  //// Other Items
+  // Chefstaves
+  2578, // Staff of the Short Order Cook
+  2601, // Staff of the Midnight Snack
+  2602, // Staff of Blood and Pudding
+  2722, // Staff of the Greasefire
+  2723, // Staff of the Grand Flambé
+  2740, // Staff of the Walk-In Freezer
+  2749, // Staff of the Grease Trap
+  2826, // Staff of the Kitchen Floor
+  3390, // Staff of the Deepest Freeze
+  3436, // Staff of the Teapot Tempest
+  3437, // Staff of the Black Kettle
+  3438, // Staff of the Well-Tempered Cauldron
+  4165, // Staff of the Soupbone
+  5758, // Staff of Holiday Sensations
+  5761, // Staff of the Scummy Sink
+  6482, // Staff of the Roaring Hearth
+  7351, // Staff of the Electric Range
+  9894, // Staff of Kitchen Royalty
+  10035, // Staff of Frozen Lard
+  10424, // Staff of the Peppermint Twist
+
+  // Jack's Swagger Shack
+  5656, // Huggler Radio
+  5659, // insulting hat
+  5660, // offensive moustache
+  5661, // hairshirt
+  5663, // cursed microwave
+  5664, // cursed pony keg
+  5668, // bagged stuffed "L"
+  5669, // stuffed club
+  5674, // stuffed "L"
+  8283, // The Cocktail Shaker
+  9123, // School of Hard Knocks Diploma
+  10207, // [glitch season reward name]
+  10325, // Law of Averages
+  10640, // Universal Seasoning
+
+  // Ultra rares
+  875, // crazy bastard sword
+  876, // incredibly dense meat gem
+  877, // Talisman of Baio
+  878, // hypnodisk
+  1236, // hockey stick of furious angry rage
+  1519, // Talisman of Bakula
+  1687, // Platinum Yendorian Express Card
+  1795, // Counterclockwise Watch
+  2097, // 17-ball
+  2847, // Dallas Dynasty Falcon Crest shield
+  6592, // optimal spreadsheet
+  7201, // The Nuge's favorite crossbow
+  9117, // repaid diaper
+
   //// Hobopolis
   // Hobo Nickles
   3220, // hobo code binder
@@ -63,7 +156,6 @@ export const specialItems = [
   3387, // Zombo's skull ring
   3388, // Zombo's empty eye
   3389, // Frosty's arm
-  3390, // Staff of the Deepest Freeze
   3391, // Frosty's iceball
   3392, // Oscus's garbage can lid
   3393, // Oscus's neverending soda

--- a/packages/greenbox-data/data/items.ts
+++ b/packages/greenbox-data/data/items.ts
@@ -5,7 +5,12 @@ export const specialItems = [
   2720, // hand-carved bow
   2721, // hand-carved staff
 
-  // secret from the future
+  // Hyboria? I don't even...
+  4041, // pig-iron helm
+  4042, // pig-iron shinguards
+  4043, // pig-iron bracers
+
+  // Future
   4108, // monstrous monocle
   4109, // musty moccasins
   4110, // molten medallion
@@ -13,7 +18,7 @@ export const specialItems = [
   4112, // bitter bowtie
   4113, // bewitching boots
 
-  // Reflection of a Map
+  // A Moment of Reflection
   4510, // walrus ice cream
   4511, // beautiful soup
   4512, // eggman noodles
@@ -22,7 +27,7 @@ export const specialItems = [
   4516, // missing wine
   4519, // ittah bittah hookah
 
-  // psychoanalytic jar
+  // Psychoanalytic Jar
   6057, // Meatcleaver
   6067, // Truthsayer
   6108, // Ginsu™

--- a/packages/greenbox-web/src/components/Familiars.tsx
+++ b/packages/greenbox-web/src/components/Familiars.tsx
@@ -57,6 +57,7 @@ export default function Familiars() {
   return (
     <Section
       title="Familiars"
+      wiki="Category:Familiars"
       icon="itemimages/terrarium.gif"
       loading={loading}
       values={[

--- a/packages/greenbox-web/src/components/IotMs.tsx
+++ b/packages/greenbox-web/src/components/IotMs.tsx
@@ -56,6 +56,7 @@ export default function IotMs() {
   return (
     <Section
       title="IotMs"
+      wiki="Mr. Store"
       icon="itemimages/mracc.gif"
       loading={loading}
       values={[

--- a/packages/greenbox-web/src/components/ItemGridSection.tsx
+++ b/packages/greenbox-web/src/components/ItemGridSection.tsx
@@ -1,0 +1,24 @@
+import { useAppSelector } from "../hooks";
+import { selectIdToPlayerItems } from "../store";
+
+import ItemGrid from "./ItemGrid";
+import Section from "./Section";
+
+type Props = {
+  title: string;
+  icon: string;
+  items: number[];
+};
+
+export default function ItemGridSection({ title, icon, items }: Props) {
+  const playerItems = useAppSelector(selectIdToPlayerItems);
+
+  return (
+    <Section title={title} icon={icon} loading={false} values={[]} max={1}>
+      <ItemGrid
+        items={items}
+        playerItems={items.map((id) => playerItems[id]?.[1] ?? 0)}
+      />
+    </Section>
+  );
+}

--- a/packages/greenbox-web/src/components/MainPage.tsx
+++ b/packages/greenbox-web/src/components/MainPage.tsx
@@ -17,6 +17,8 @@ import { fetchAll, fetchPlayerData, loadPlayerData } from "../store";
 import ClanDungeons from "./ClanDungeons";
 import General from "./General";
 import Header from "./Header";
+import OtherItems from "./OtherItems";
+import QuestRewards from "./QuestRewards";
 
 export default function MainPage() {
   const [directValue] = useQueryParam("d", StringParam);
@@ -87,6 +89,8 @@ export default function MainPage() {
         <TabList>
           <Tab>General</Tab>
           <Tab>Clan Dungeons</Tab>
+          <Tab>Quest Rewards</Tab>
+          <Tab>Miscellaneous</Tab>
         </TabList>
         <TabPanels>
           <TabPanel p={0}>
@@ -94,6 +98,12 @@ export default function MainPage() {
           </TabPanel>
           <TabPanel p={0}>
             <ClanDungeons />
+          </TabPanel>
+          <TabPanel p={0}>
+            <QuestRewards />
+          </TabPanel>
+          <TabPanel p={0}>
+            <OtherItems />
           </TabPanel>
         </TabPanels>
       </Tabs>

--- a/packages/greenbox-web/src/components/OtherItems.tsx
+++ b/packages/greenbox-web/src/components/OtherItems.tsx
@@ -72,7 +72,7 @@ export default function OtherItems() {
         items={SWAGGER}
       />
       <ItemGridSection
-        title="Ultra Rare"
+        title="Ultra Rares"
         icon="itemimages/ribbon.gif"
         items={ULTRA_RARE}
       />

--- a/packages/greenbox-web/src/components/OtherItems.tsx
+++ b/packages/greenbox-web/src/components/OtherItems.tsx
@@ -1,0 +1,81 @@
+import { Accordion } from "@chakra-ui/react";
+
+import ItemGridSection from "./ItemGridSection";
+
+const RODORIC = [
+  2578, // Staff of the Short Order Cook
+  2601, // Staff of the Midnight Snack
+  2602, // Staff of Blood and Pudding
+  2722, // Staff of the Greasefire
+  2723, // Staff of the Grand Flambé
+  2740, // Staff of the Walk-In Freezer
+  2749, // Staff of the Grease Trap
+  2826, // Staff of the Kitchen Floor
+  3390, // Staff of the Deepest Freeze
+  3436, // Staff of the Teapot Tempest
+  3437, // Staff of the Black Kettle
+  3438, // Staff of the Well-Tempered Cauldron
+  4165, // Staff of the Soupbone
+  5758, // Staff of Holiday Sensations
+  5761, // Staff of the Scummy Sink
+  6482, // Staff of the Roaring Hearth
+  7351, // Staff of the Electric Range
+  9894, // Staff of Kitchen Royalty
+  10035, // Staff of Frozen Lard
+  10424, // Staff of the Peppermint Twist
+];
+
+const SWAGGER = [
+  5656, // Huggler Radio
+  5659, // insulting hat
+  5660, // offensive moustache
+  5661, // hairshirt
+  5663, // cursed microwave
+  5664, // cursed pony keg
+  5668, // bagged stuffed "L"
+  5669, // stuffed club
+  5674, // stuffed "L"
+  8283, // The Cocktail Shaker
+  9123, // School of Hard Knocks Diploma
+  10207, // [glitch season reward name]
+  10325, // Law of Averages
+  10640, // Universal Seasoning
+];
+
+const ULTRA_RARE = [
+  875, // crazy bastard sword
+  876, // incredibly dense meat gem
+  877, // Talisman of Baio
+  878, // hypnodisk
+  1236, // hockey stick of furious angry rage
+  1519, // Talisman of Bakula
+  1687, // Platinum Yendorian Express Card
+  1795, // Counterclockwise Watch
+  2097, // 17-ball
+  2847, // Dallas Dynasty Falcon Crest shield
+  6592, // optimal spreadsheet
+  7201, // The Nuge's favorite crossbow
+  9117, // repaid diaper
+];
+
+export default function OtherItems() {
+  return (
+    <Accordion allowMultiple>
+      <ItemGridSection
+        title="Rodoric, the Staffcrafter"
+        icon="itemimages/meatstaff.gif"
+        items={RODORIC}
+      />
+      <ItemGridSection
+        title="Jack's Swagger Shack"
+        icon="itemimages/angry.gif"
+        items={SWAGGER}
+      />
+      <ItemGridSection
+        title="Ultra Rare"
+        icon="itemimages/ribbon.gif"
+        items={ULTRA_RARE}
+      />
+    </Accordion>
+  );
+}

--- a/packages/greenbox-web/src/components/Paths.tsx
+++ b/packages/greenbox-web/src/components/Paths.tsx
@@ -98,6 +98,7 @@ export default function Paths() {
   return (
     <Section
       title="Paths"
+      wiki="Special Challenge Path"
       icon="itemimages/map.gif"
       loading={loading}
       values={[

--- a/packages/greenbox-web/src/components/QuestRewards.tsx
+++ b/packages/greenbox-web/src/components/QuestRewards.tsx
@@ -8,6 +8,12 @@ const MARTY = [
   2721, // hand-carved staff
 ];
 
+const HYBORIA = [
+  4041, // pig-iron helm
+  4042, // pig-iron shinguards
+  4043, // pig-iron bracers
+]
+
 const FUTURE = [
   4108, // monstrous monocle
   4109, // musty moccasins
@@ -54,12 +60,17 @@ export default function QuestRewards() {
         items={MARTY}
       />
       <ItemGridSection
-        title="Secret from the Future"
+        title="Hyboria? I don't even..."
+        icon="itemimages/mem_robe.gif"
+        items={HYBORIA}
+      />
+      <ItemGridSection
+        title="Future"
         icon="itemimages/futurebox.gif"
         items={FUTURE}
       />
       <ItemGridSection
-        title="Reflection of a Map"
+        title="A Moment of Reflection"
         icon="itemimages/revmap.gif"
         items={REFLECTION}
       />

--- a/packages/greenbox-web/src/components/QuestRewards.tsx
+++ b/packages/greenbox-web/src/components/QuestRewards.tsx
@@ -1,0 +1,78 @@
+import { Accordion } from "@chakra-ui/react";
+
+import ItemGridSection from "./ItemGridSection";
+
+const MARTY = [
+  2719, // hand-carved bokken
+  2720, // hand-carved bow
+  2721, // hand-carved staff
+];
+
+const FUTURE = [
+  4108, // monstrous monocle
+  4109, // musty moccasins
+  4110, // molten medallion
+  4111, // brazen bracelet
+  4112, // bitter bowtie
+  4113, // bewitching boots
+];
+
+const REFLECTION = [
+  4510, // walrus ice cream
+  4511, // beautiful soup
+  4512, // eggman noodles
+  4513, // Vial of jus de larmes
+  4515, // Lobster qua Grill
+  4516, // missing wine
+  4519, // ittah bittah hookah
+];
+
+const PSYCHOANALYTIC = [
+  6057, // Meatcleaver
+  6067, // Truthsayer
+  6108, // Ginsu™
+  6133, // White Dragon Fang
+  6146, // Sword of Procedural Generation
+  6157, // Byte
+  6168, // Bloodbath
+];
+
+const GRIMSTONE = [
+  7131, // silver cow creamer
+  7134, // wolf whistle
+  7137, // witch's bra
+  7140, // spinning wheel
+  7143, // hare pin
+];
+
+export default function QuestRewards() {
+  return (
+    <Accordion allowMultiple>
+      <ItemGridSection
+        title="Marty's Quest"
+        icon="itemimages/balaclava.gif"
+        items={MARTY}
+      />
+      <ItemGridSection
+        title="Secret from the Future"
+        icon="itemimages/futurebox.gif"
+        items={FUTURE}
+      />
+      <ItemGridSection
+        title="Reflection of a Map"
+        icon="itemimages/revmap.gif"
+        items={REFLECTION}
+      />
+      <ItemGridSection
+        title="Psychoanalytic Jar"
+        icon="itemimages/analjar_empty.gif"
+        items={PSYCHOANALYTIC}
+      />
+      <ItemGridSection
+        title="We All Wear Masks"
+        icon="itemimages/grimstonemask.gif"
+        items={GRIMSTONE}
+      />
+    </Accordion>
+  );
+}

--- a/packages/greenbox-web/src/components/QuestRewards.tsx
+++ b/packages/greenbox-web/src/components/QuestRewards.tsx
@@ -12,7 +12,7 @@ const HYBORIA = [
   4041, // pig-iron helm
   4042, // pig-iron shinguards
   4043, // pig-iron bracers
-]
+];
 
 const FUTURE = [
   4108, // monstrous monocle

--- a/packages/greenbox-web/src/components/Section.tsx
+++ b/packages/greenbox-web/src/components/Section.tsx
@@ -11,9 +11,11 @@ import {
 import AlphaImage from "./AlphaImage";
 import Progress from "./Progress";
 import Spinner from "./Spinner";
+import WikiSearchLink from "./WikiSearchLink";
 
 interface Props extends React.PropsWithChildren {
   title: string;
+  wiki?: string;
   icon: string;
   loading?: boolean;
   values: React.ComponentProps<typeof Progress>["values"];
@@ -22,6 +24,7 @@ interface Props extends React.PropsWithChildren {
 
 export default function Section({
   title,
+  wiki,
   icon,
   loading = false,
   values,
@@ -30,18 +33,21 @@ export default function Section({
 }: Props) {
   return (
     <AccordionItem isDisabled={loading}>
-      <AccordionButton fontSize="3xl">
-        <Stack direction="row" flex="1" textAlign="left">
-          <AlphaImage src={icon} />
-          <Heading fontSize={["xl", null, "3xl"]} fontWeight="normal">
-            {title}
-          </Heading>
-        </Stack>
-        <Box alignSelf="stretch" flex="1 1">
-          <Progress values={values} max={max} />
-        </Box>
-        {loading ? <Spinner /> : <AccordionIcon />}
-      </AccordionButton>
+      <Stack direction="row">
+        <AccordionButton fontSize="3xl">
+          <Stack direction="row" flex="1" textAlign="left">
+            <AlphaImage src={icon} />
+            <Heading fontSize={["xl", null, "3xl"]} fontWeight="normal">
+              {title}
+            </Heading>
+          </Stack>
+          <Box alignSelf="stretch" flex="1 1">
+            <Progress values={values} max={max} />
+          </Box>
+          {loading ? <Spinner /> : <AccordionIcon />}
+        </AccordionButton>
+        <WikiSearchLink page={wiki ?? title} text='?' fontSize="small"></WikiSearchLink>
+      </Stack>
       <AccordionPanel>
         <Stack spacing={4}>{children}</Stack>
       </AccordionPanel>

--- a/packages/greenbox-web/src/components/Section.tsx
+++ b/packages/greenbox-web/src/components/Section.tsx
@@ -46,7 +46,11 @@ export default function Section({
           </Box>
           {loading ? <Spinner /> : <AccordionIcon />}
         </AccordionButton>
-        <WikiSearchLink page={wiki ?? title} text='?' fontSize="small"></WikiSearchLink>
+        <WikiSearchLink
+          page={wiki ?? title}
+          text="?"
+          fontSize="small"
+        ></WikiSearchLink>
       </Stack>
       <AccordionPanel>
         <Stack spacing={4}>{children}</Stack>

--- a/packages/greenbox-web/src/components/WikiSearchLink.tsx
+++ b/packages/greenbox-web/src/components/WikiSearchLink.tsx
@@ -1,0 +1,19 @@
+import { Link } from "@chakra-ui/react";
+
+type Props = {
+  page: string;
+  text: string;
+  fontSize: string;
+};
+
+export default function WikiSearchLink({ page, text, fontSize }: Props) {
+  return (
+    <Link
+      fontSize={fontSize}
+      href={`https://kol.coldfront.net/thekolwiki/index.php?search=${page}&title=Special%3ASearch`}
+      isExternal={true}
+    >
+      {text}
+    </Link>
+  );
+}


### PR DESCRIPTION
Adding tracking of additional quest rewards and some other miscellaneous items. The word quest here may be a bit loose but I didn't see the need to distinguish between like questlog quests and like other kinds of puzzles that have rewards.

I still have some quests and items to add before I'm done with this, but my thought process here is only to show items that a player can still possibly acquire, similar as how we decided to not show boss items for the haunted sorority house. For example so far I decided not to show items from the underworld trunk since [The Shivering Timbers](https://kol.coldfront.net/thekolwiki/index.php/The_Shivering_Timbers) is now impossible to access.

Ultra rares may be a spicy addition but it's still feasible that someone could get their hands on one (I did decide to leave out consolation ribbon though since I don't want to encourage that behavior).

I wanted to get some feedback about the layout before I continue since right now it's just a number of items each under a separate header, here are the screenshots of what I have locally:

<img width="991" alt="image" src="https://github.com/loathers/greenbox/assets/1320480/ffd6ae53-8c32-438f-a353-0c872a97de99">
<img width="986" alt="image" src="https://github.com/loathers/greenbox/assets/1320480/93d9764e-b514-49f7-ade4-402998156c31">
