### PR TITLE
Fix bug that greened all boxes

### DIFF
--- a/packages/greenbox-web/src/components/Thing.tsx
+++ b/packages/greenbox-web/src/components/Thing.tsx
@@ -34,7 +34,7 @@ function styleFromStatus(state: StateType, bg: string) {
     }
     default: {
       return {
-        backgroundColor: "complete",
+        backgroundColor: bg,
       };
     }
   }


### PR DESCRIPTION
#83 introduced a bug where all boxes were displaying as green. It seems like an unintentional change, but if it was intentional to make the intent of the function more clear, we could make some other changes instead. Open to feedback.